### PR TITLE
Add real data policy and templates

### DIFF
--- a/docs/real-data-policy.md
+++ b/docs/real-data-policy.md
@@ -1,0 +1,100 @@
+# Real Data Policy
+
+Large IQ recordings are essential for SDR experiments, but they should not be committed directly to this repository.
+
+## Why raw IQ files should stay outside Git
+
+| Problem | Why it matters |
+|---|---|
+| Repository bloat | CI and clone times become slow |
+| Binary diffs | Git cannot efficiently review raw signal changes |
+| Reproducibility risk | files without metadata are ambiguous |
+| Licensing/privacy | captures may contain restricted or sensitive signals |
+| Storage limits | long captures can easily reach gigabytes |
+
+## Recommended storage options
+
+| Option | Best use |
+|---|---|
+| GitHub Releases | small curated demo datasets |
+| Git LFS | small-to-medium binary fixtures, used carefully |
+| Zenodo | citable research datasets with DOI |
+| institutional storage | internal/private experimental data |
+| cloud storage link | temporary collaboration datasets |
+
+## Required sidecar metadata
+
+Every real capture must have a metadata file next to it:
+
+```text
+capture_name.ci16
+capture_name.metadata.json
+```
+
+The metadata must include:
+
+- sample rate;
+- center frequency;
+- IQ format;
+- endian and I/Q order;
+- sample count;
+- receiver and gain settings;
+- expected signal offset;
+- capture date/time;
+- hardware setup;
+- safety/attenuation notes;
+- license or access notes.
+
+## File naming convention
+
+Use descriptive names:
+
+```text
+YYYYMMDD_device_band_signal_samplerate_format.ci16
+```
+
+Example:
+
+```text
+20260511_ad9363_915mhz_qpsk_2p4msps_ci16.ci16
+20260511_ad9363_915mhz_qpsk_2p4msps_ci16.metadata.json
+```
+
+## What can be committed
+
+Commit these files:
+
+- metadata templates;
+- small synthetic fixtures;
+- analysis scripts;
+- plots and metrics JSON;
+- links to external datasets;
+- README files describing how to obtain data.
+
+Do not commit:
+
+- multi-MB or multi-GB raw captures;
+- undocumented IQ dumps;
+- captures with unclear legal status;
+- files containing sensitive or private communications.
+
+## Minimal dataset README
+
+Every external dataset folder should include:
+
+```text
+README.md
+metadata.json
+download_instructions.md
+checksum.txt
+```
+
+## Reproducibility checklist
+
+- [ ] External link is documented.
+- [ ] Metadata JSON is included.
+- [ ] SHA256 checksum is included.
+- [ ] Capture format is described.
+- [ ] Analysis command is provided.
+- [ ] License/access conditions are stated.
+- [ ] The dataset is not required for basic CI.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
       - "Reproducibility guide": reproducibility-guide.md
       - "Lab report template": lab-report-template.md
       - "IQ metadata guide": iq-recording-metadata.md
+      - "Real data policy": real-data-policy.md
   - "Demo (IEEE figures)": demo.md
   - "GitHub demo notes": demo_readme.md
   - "IEEE-style guide": ieee_style_guide.md

--- a/templates/capture_metadata.template.json
+++ b/templates/capture_metadata.template.json
@@ -1,0 +1,37 @@
+{
+  "recording_id": "YYYYMMDD_device_band_signal_samplerate_format",
+  "description": "Short description of the capture",
+  "created_utc": "YYYY-MM-DDTHH:MM:SSZ",
+  "sample_rate_hz": 2400000,
+  "center_frequency_hz": 915000000,
+  "iq_format": "ci16",
+  "endianness": "little",
+  "i_first": true,
+  "sample_count": 0,
+  "expected_signal_offset_hz": 0,
+  "receiver": {
+    "device": "AD9363 / RTL-SDR / HDSDR / other",
+    "serial": "optional",
+    "gain_mode": "manual",
+    "gain_db": 0,
+    "rf_bandwidth_hz": 0,
+    "external_attenuation_db": 0
+  },
+  "transmitter": {
+    "device": "optional",
+    "tx_gain_db": 0,
+    "waveform": "tone / qpsk / other"
+  },
+  "processing": {
+    "fft_length": 65536,
+    "window": "hann",
+    "normalization": "dBFS"
+  },
+  "quality_expectations": {
+    "max_clipping_fraction": 0.001,
+    "max_dc_offset": 0.05,
+    "max_frequency_error_hz": 200,
+    "min_snr_db": 20
+  },
+  "license_or_access": "state dataset license or private access conditions"
+}

--- a/templates/final_project_report.template.md
+++ b/templates/final_project_report.template.md
@@ -1,0 +1,59 @@
+# Final Project Report Template
+
+## Abstract
+
+Summarize the project goal, method and main result.
+
+## 1. Requirements
+
+- Goal:
+- Constraints:
+- Success criteria:
+
+## 2. Architecture
+
+Include system diagram and interface table.
+
+## 3. Modeling
+
+Describe Python/MATLAB reference model.
+
+## 4. Fixed-Point and RTL
+
+State formats, scaling, saturation and verification results.
+
+## 5. RF Setup
+
+State center frequencies, bandwidths, gains, attenuation and safety checks.
+
+## 6. IQ Recording
+
+Attach metadata JSON and dataset access notes.
+
+## 7. Analysis and Synchronization
+
+Describe FFT, DDC, CFO/phase/timing correction and decisions.
+
+## 8. Results
+
+| Criterion | Target | Measured | Status |
+|---|---:|---:|---|
+| Frequency error |  |  |  |
+| SNR |  |  |  |
+| EVM |  |  |  |
+| BER |  |  |  |
+| Clipping fraction |  |  |  |
+
+## 9. Reproducibility
+
+```bash
+make smoke
+```
+
+## 10. Limitations and Next Steps
+
+State limitations honestly.
+
+## Conclusion
+
+State the final engineering result.

--- a/templates/lab_report.template.md
+++ b/templates/lab_report.template.md
@@ -1,0 +1,46 @@
+# Lab Report Template
+
+## 1. Goal
+
+State the goal of the lab in one paragraph.
+
+## 2. Setup
+
+| Parameter | Value |
+|---|---:|
+| Hardware |  |
+| Software |  |
+| Sample rate |  |
+| Center frequency |  |
+| IQ format |  |
+| Gain settings |  |
+
+## 3. Method
+
+Describe the processing chain, scripts and assumptions.
+
+## 4. Results
+
+Attach figures and metrics.
+
+| Metric | Value | Unit |
+|---|---:|---|
+| Peak frequency |  | Hz |
+| Frequency error |  | Hz |
+| SNR |  | dB |
+| EVM |  | % |
+| BER |  |  |
+
+## 5. Discussion
+
+Explain what worked, what failed and why.
+
+## 6. Reproducibility
+
+```bash
+# commands used to reproduce the result
+```
+
+## 7. Conclusion
+
+State whether the lab met the success criteria.

--- a/templates/rf_safety_checklist.template.md
+++ b/templates/rf_safety_checklist.template.md
@@ -1,0 +1,46 @@
+# RF Safety Checklist Template
+
+## Setup
+
+| Item | Value |
+|---|---|
+| Date |  |
+| Operator |  |
+| TX device |  |
+| RX device |  |
+| Center frequency |  |
+| Sample rate |  |
+| External attenuation |  |
+
+## Before connection
+
+- [ ] TX is off.
+- [ ] RX gain is set manually.
+- [ ] External attenuation is installed.
+- [ ] Frequency plan is documented.
+- [ ] Cable and connectors are inspected.
+- [ ] DC path is understood.
+- [ ] Maximum expected level is safe.
+
+## First power-on
+
+- [ ] RX noise floor observed first.
+- [ ] TX enabled at minimum gain.
+- [ ] Spectrum checked for overload.
+- [ ] Gain increased gradually.
+- [ ] Metadata updated with actual settings.
+
+## Overload indicators
+
+- [ ] Flat-top spectrum absent.
+- [ ] Harmonics/spurs acceptable.
+- [ ] Noise floor does not rise unexpectedly.
+- [ ] Clipping fraction acceptable.
+
+## Conclusion
+
+The setup is safe / unsafe for continued operation because:
+
+```text
+
+```


### PR DESCRIPTION
Добавляет практический слой для работы с реальными IQ-данными:

- docs/real-data-policy.md
- templates/capture_metadata.template.json
- templates/lab_report.template.md
- templates/final_project_report.template.md
- templates/rf_safety_checklist.template.md
- подключение Real data policy в MkDocs

Сливается отдельным небольшим squash-коммитом.