### PR TITLE
Add README quick start and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,134 @@
 # Zynq SDR Course / Курс SDR на Zynq
 
 [![Bilingual](https://img.shields.io/badge/language-RU%20%2F%20EN-blueviolet)](#)
-[![MkDocs](https://img.shields.io/badge/site-MkDocs%20Material-informational)](#)
-[![IEEE-style plots](https://img.shields.io/badge/plots-IEEE--style%20auto--generated-success)](.github/workflows/generate_plots.yml)
-[![Pages deploy](https://img.shields.io/badge/pages-deploy%20manual-lightgrey)](.github/workflows/pages.yml)
+[![MkDocs](https://img.shields.io/badge/site-MkDocs%20Material-informational)](mkdocs.yml)
+[![Full Course Smoke](https://github.com/Lay007/zynq-sdr-course/actions/workflows/full_course_smoke.yml/badge.svg)](https://github.com/Lay007/zynq-sdr-course/actions/workflows/full_course_smoke.yml)
+[![Block 5 HDL](https://github.com/Lay007/zynq-sdr-course/actions/workflows/block5_hdl.yml/badge.svg)](https://github.com/Lay007/zynq-sdr-course/actions/workflows/block5_hdl.yml)
+[![Block 8 Sync](https://github.com/Lay007/zynq-sdr-course/actions/workflows/block8_sync.yml/badge.svg)](https://github.com/Lay007/zynq-sdr-course/actions/workflows/block8_sync.yml)
+[![Block 9 Recording](https://github.com/Lay007/zynq-sdr-course/actions/workflows/block9_recording_analysis.yml/badge.svg)](https://github.com/Lay007/zynq-sdr-course/actions/workflows/block9_recording_analysis.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
-A **bilingual engineering course on SDR** that connects signal theory, DSP, fixed-point modeling, HDL/FPGA flow, RF front-end understanding, board-level experiments, measurements, and engineering reports.
+A **bilingual engineering course on Software-Defined Radio** that connects signal theory, DSP, fixed-point modeling, HDL/FPGA flow, RF frontend understanding, TX/RX chains, synchronization, IQ recording, practical electronics and final engineering reports.
 
-Это **двуязычный инженерный курс по SDR**, который связывает теорию сигналов, DSP, fixed-point моделирование, HDL/FPGA flow, понимание радиотракта, практическую работу с платой, измерения и инженерные отчёты.
+Это **двуязычный инженерный курс по SDR**, который связывает теорию сигналов, DSP, fixed-point моделирование, HDL/FPGA flow, радиотракт, TX/RX цепочки, синхронизацию, запись IQ, практическую электронику и итоговые инженерные отчёты.
 
 ![Zynq SDR Course Pipeline](docs/assets/course_pipeline.svg)
+
+---
+
+## Start here in 10 minutes / Быстрый старт за 10 минут
+
+```bash
+git clone https://github.com/Lay007/zynq-sdr-course.git
+cd zynq-sdr-course
+python -m pip install -r requirements.txt
+make docs
+make labs
+```
+
+For the full local smoke check, install Icarus Verilog (`iverilog`) and run:
+
+```bash
+make smoke
+```
+
+Для полной локальной проверки установите Icarus Verilog (`iverilog`) и выполните:
+
+```bash
+make smoke
+```
+
+Useful commands:
+
+| Command | Purpose |
+|---|---|
+| `make install` | install Python dependencies |
+| `make docs` | strict MkDocs build |
+| `make serve` | local MkDocs preview |
+| `make labs` | run representative executable Python labs |
+| `make hdl` | run Block 5 Verilog smoke tests |
+| `make smoke` | run docs + labs + HDL checks |
+| `make clean` | remove generated local build artifacts |
+
+---
+
+## Fast navigation / Быстрая навигация
+
+| Page | Why open it |
+|---|---|
+| [Course demo dashboard](docs/demo-dashboard.md) | fast visual overview of executable course artifacts |
+| [Visual course map](docs/course-map.md) | complete engineering route from theory to final project |
+| [Portfolio view](docs/portfolio-view.md) | what this repository demonstrates professionally |
+| [Model → FPGA → RF → Measurement](docs/model-to-measurement.md) | core system-level route |
+| [Real data policy](docs/real-data-policy.md) | how to store and describe real IQ captures |
+| [Reproducibility guide](docs/reproducibility-guide.md) | how to reproduce generated results |
+
+---
 
 ## What this course teaches / Чему учит курс
 
 | Layer | Engineering result |
 |---|---|
 | **Signals and spectra** | sampling, bandwidth, aliasing, modulation basics |
-| **MATLAB / Simulink modeling** | reference waveforms, plots, repeatable experiments |
+| **DSP modeling** | FFT, FIR, mixing, decimation, reference plots |
 | **Fixed-point DSP** | word length, scaling, quantization, implementation error |
 | **HDL / FPGA** | Verilog blocks, streaming DSP, latency, testbenches |
 | **Zynq + AD9363 hardware** | RF configuration, board-level signal generation and capture |
-| **External measurement** | RTL-SDR, HDSDR, IQ recording, independent observation |
-| **Analysis and reports** | FFT, EVM, BER, SNR, engineering conclusions |
-
-## Quick navigation / Быстрая навигация
-
-- [Русская версия / Russian version](README_ru.md)
-- [English version / Английская версия](README_en.md)
-- [IEEE-style guide](docs/ieee_style_guide.md)
-- [GitHub demo notes](docs/demo_readme.md)
-- [Course blocks](#course-blocks--блоки-курса)
-- [Hardware baseline](#hardware-baseline--аппаратная-база)
-- [Generated demo plots](#generated-demo-plots--автоматические-демо-графики)
+| **TX/RX chains** | DUC/DDC, frequency plans, loopback metrics |
+| **Synchronization** | CFO, phase, timing recovery, EVM and BER |
+| **IQ recording** | CI16/CU8/CF32 readers, metadata and capture quality checks |
+| **Electronics / KiCad** | attenuators, RC filters, RF safety and schematic discipline |
+| **Integrated project** | requirements, architecture, measurement report and portfolio output |
 
 ---
 
 ## Why this repository matters / Почему этот репозиторий важен
 
-This repository is not just a collection of markdown notes. It is structured as a **teaching and implementation path** from first SDR concepts to hardware-oriented project work.
+This repository is not just a collection of markdown notes. It is structured as a **teaching, implementation and verification path** from first SDR concepts to measurement-oriented project work.
 
-Этот репозиторий — не просто набор markdown-файлов. Он оформлен как **учебный и инженерный маршрут** от первых понятий SDR до проектной работы, ориентированной на железо.
+Этот репозиторий — не просто набор markdown-файлов. Он оформлен как **учебный, инженерный и верифицируемый маршрут** от первых понятий SDR до проектной работы с измерениями.
 
 The course is designed around a complete engineering chain:
 
-Курс построен вокруг полной инженерной цепочки:
+```text
+theory -> modeling -> fixed-point -> HDL/FPGA -> RF frontend -> TX/RX -> synchronization -> IQ recording -> electronics -> integrated project
+```
 
-**theory → modeling → fixed-point → HDL / FPGA → SDR board → external reception → IQ recording → analysis → circuit design → final project**
+```text
+теория -> моделирование -> fixed-point -> HDL/FPGA -> радиотракт -> TX/RX -> синхронизация -> запись IQ -> электроника -> интегрированный проект
+```
 
-**теория → моделирование → fixed-point → HDL / FPGA → SDR-плата → внешний приём → запись IQ → анализ → схемотехника → итоговый проект**
+---
+
+## Reproducibility / Воспроизводимость
+
+Representative executable labs can be launched with one command:
+
+```bash
+python tools/run_all_labs.py
+```
+
+The script creates:
+
+```text
+docs/assets/course_reproducibility_summary.json
+docs/assets/course_reproducibility_summary.md
+```
+
+The full smoke workflow checks:
+
+- MkDocs strict build;
+- representative Python labs;
+- Block 5 Verilog testbenches;
+- generated summary artifacts.
 
 ---
 
 ## Generated demo plots / Автоматические демо-графики
 
-Auto-generated IEEE-style plots are produced by GitHub Actions from `tools/generate_ieee_plots.py` and stored in `docs/assets`.
+Auto-generated IEEE-style plots are produced by GitHub Actions and stored in `docs/assets`.
 
-Графики в IEEE-style автоматически генерируются через GitHub Actions из `tools/generate_ieee_plots.py` и сохраняются в `docs/assets`.
+Графики в IEEE-style автоматически генерируются через GitHub Actions и сохраняются в `docs/assets`.
 
 | Lab | Demo plot | Engineering meaning |
 |---|---|---|
@@ -87,20 +159,11 @@ Auto-generated IEEE-style plots are produced by GitHub Actions from `tools/gener
 
 ---
 
-## Current state / Текущее состояние
-
-- **Block 1 is populated in bilingual form** / **Блок 1 наполнен в двуязычном формате**
-- **IEEE-style plot generation is automated through GitHub Actions** / **Генерация IEEE-style графиков автоматизирована через GitHub Actions**
-- **MkDocs deployment is temporarily manual** / **Деплой MkDocs временно переведён в ручной режим**
-- **Visual landing pipeline is available** / **Добавлена наглядная карта инженерного маршрута**
-
----
-
 ## Hardware baseline / Аппаратная база
 
-The current hands-on setup already includes a simple external receiver and a board-level SDR platform for practical experiments.
+The current hands-on setup includes an external receiver and a board-level SDR platform for practical experiments.
 
-Текущая практическая аппаратная база уже включает простой внешний приёмник и SDR-платформу на уровне платы для лабораторных работ и экспериментов.
+Текущая практическая аппаратная база включает внешний приёмник и SDR-платформу на уровне платы для лабораторных работ и экспериментов.
 
 ### RTL-SDR V3 Pro
 
@@ -129,51 +192,11 @@ flowchart TB
     ANALYSIS -. parameter tuning .-> CFG
 ```
 
-**Practical flow:** generate a signal on the Zynq/ADRV platform → receive it with RTL-SDR → observe it in HDSDR → record IQ samples → analyze the recording in multiple software environments.
+**Practical flow:** generate a signal on the Zynq/AD9363 platform → receive it with RTL-SDR → observe it in HDSDR → record IQ samples → analyze the recording in multiple software environments.
 
-**Практический поток:** сформировать сигнал на платформе Zynq/ADRV → принять его через RTL-SDR → наблюдать в HDSDR → записать IQ-данные → проанализировать запись в нескольких программных средах.
+**Практический поток:** сформировать сигнал на платформе Zynq/AD9363 → принять его через RTL-SDR → наблюдать в HDSDR → записать IQ-данные → проанализировать запись в нескольких программных средах.
 
-## Level 2: Zynq / FPGA signal path / Уровень 2: тракт Zynq / FPGA
-
-```mermaid
-flowchart TB
-    MODEL["Reference model<br/>expected samples and spectra"]
-    CFG["Experiment configuration<br/>RF frequency, gain, bandwidth and data rate"]
-
-    subgraph SOC["Zynq-7020 SoC"]
-        direction TB
-        PS["Processing System / ARM<br/>control software, scripts and register access"]
-        PL["Programmable Logic / FPGA<br/>deterministic streaming DSP pipeline"]
-        PS --> PL
-    end
-
-    AD["AD9363 RF frontend<br/>DAC, mixer, analog filters and I/Q interface"]
-    LINK["RF link<br/>coax, attenuator or antenna path"]
-    RX["External measurement chain<br/>RTL-SDR, HDSDR, IQ file and offline analysis"]
-
-    MODEL --> PL
-    CFG --> PS
-    PL --> AD --> LINK --> RX
-    RX -. model correction .-> MODEL
-    RX -. parameter tuning .-> CFG
-```
-
-## Level 3: SDR TX/RX processing chain / Уровень 3: TX/RX тракт SDR
-
-```mermaid
-flowchart TB
-    SRC["1. Source and framing<br/>tone, packet, payload or waveform definition"]
-    MOD["2. Modulation and shaping<br/>BPSK/QPSK/QAM/FSK plus pulse-shaping filters"]
-    TXRF["3. TX path<br/>DUC, DAC, mixer, filters and transmit gain"]
-    CHANNEL["4. Channel<br/>coax, attenuator, antenna path, noise and offsets"]
-    RXRF["5. RX path<br/>LNA, mixer, ADC, DDC and AGC"]
-    SYNC["6. Synchronization and demodulation<br/>CFO, timing, frame sync, matched filter and bits"]
-    VALID["7. Validation and replay<br/>IQ taps, FFT, EVM, BER, reports and notebooks"]
-
-    SRC --> MOD --> TXRF --> CHANNEL --> RXRF --> SYNC --> VALID
-    VALID -. model tuning .-> MOD
-    VALID -. hardware tuning .-> RXRF
-```
+---
 
 ## Course blocks / Блоки курса
 
@@ -186,6 +209,24 @@ flowchart TB
 7. `blocks/block_07_tx_rx_chains`
 8. `blocks/block_08_modulation_and_synchronization`
 9. `blocks/block_09_recording_and_analysis_tools`
+10. `blocks/block_10_kicad_and_basic_electronics`
+11. `blocks/block_11_integrated_sdr_project`
+12. `blocks/block_12_final_projects`
+
+---
+
+## Templates / Шаблоны
+
+Reusable templates are stored in `templates/`:
+
+```text
+templates/capture_metadata.template.json
+templates/lab_report.template.md
+templates/final_project_report.template.md
+templates/rf_safety_checklist.template.md
+```
+
+---
 
 ## License / Лицензия
 


### PR DESCRIPTION
Обновляет README как входную страницу проекта:

- GitHub Actions badges
- Start here in 10 minutes
- Makefile commands
- fast navigation
- актуальная engineering chain
- reproducibility section
- обновлённый список блоков 1–12
- templates section

Сливается отдельным небольшим squash-коммитом.