### PR TITLE
Add course and lab quality gate docs

### DIFF
--- a/docs/course-quality-gates.md
+++ b/docs/course-quality-gates.md
@@ -1,0 +1,41 @@
+# Course quality gates
+
+Use this checklist before merging course, lab, HDL, documentation, or tooling changes.
+
+## Documentation quality
+
+- Run the documentation build in strict mode before publishing.
+- Keep navigation entries synchronized with created, renamed, or removed pages.
+- Keep Russian and English sections structurally aligned when content exists in both languages.
+- Prefer generated diagrams or source-controlled diagram descriptions over manually edited screenshots.
+- Add captions and context for every figure that teaches a signal-processing or hardware concept.
+
+## DSP and fixed-point quality
+
+- State the reference floating-point behavior before adding fixed-point or HDL variants.
+- Document word length, fractional length, rounding, saturation, and overflow assumptions.
+- Include at least one deterministic test vector for non-trivial DSP blocks.
+- Explain expected numerical error or tolerance when comparing models.
+- Mention latency and throughput when a block is intended for FPGA implementation.
+
+## HDL and FPGA quality
+
+- Keep HDL examples small enough to understand in isolation.
+- Add simulation notes or testbench guidance for hardware-facing blocks.
+- Document clock, reset, valid/ready, and sample-rate assumptions.
+- Avoid hiding vendor-specific behavior when a lab depends on a specific board or toolchain.
+
+## SDR and RF lab quality
+
+- Include RF safety and local regulation notes for transmitting examples.
+- Prefer receive-only or low-power lab variants where possible.
+- Record center frequency, sample rate, gain, bandwidth, and file format for IQ captures.
+- Add dataset manifests or checksums when a lab uses recorded data.
+
+## Review checklist
+
+- Documentation build passes.
+- Lab commands were checked for copy-paste usability.
+- Figures are readable on GitHub and the MkDocs site.
+- New files are linked from navigation or intentionally left unlisted.
+- No private credentials, captures, hostnames, or personal paths are committed.

--- a/docs/lab-review-checklist.md
+++ b/docs/lab-review-checklist.md
@@ -1,0 +1,34 @@
+# Lab review checklist
+
+Use this checklist for new or substantially changed practical labs.
+
+## Learning path
+
+- The lab states what the student should understand after completing it.
+- The lab connects theory to modeling, fixed-point behavior, HDL, SDR hardware, or IQ analysis.
+- Required background is listed before the procedure.
+
+## Reproducibility
+
+- Hardware, software, and toolchain versions are named.
+- All command examples are copy-paste friendly.
+- Input files, generated files, and expected outputs are described.
+- IQ files include sample rate, center frequency, bandwidth, gain, format, and byte order.
+
+## Measurement value
+
+- The lab produces at least one observable result: plot, spectrum, waveform, report, LED/logic output, or received signal.
+- Expected result ranges are stated where exact values are not stable.
+- Failure modes and debugging hints are included.
+
+## Safety
+
+- RF transmission examples include local regulation and low-power warnings.
+- Hardware wiring examples mention power, ground, and basic protection assumptions.
+- Risky host commands are marked clearly.
+
+## Maintenance
+
+- Figures are stored in the documented assets path.
+- Generated artifacts can be regenerated from source scripts when possible.
+- Russian and English versions stay structurally aligned when both are present.


### PR DESCRIPTION
## Summary

Adds two review-oriented documents:

- `docs/course-quality-gates.md` for documentation, DSP/fixed-point, HDL/FPGA, SDR/RF, and review checks;
- `docs/lab-review-checklist.md` for practical lab reproducibility, measurement value, safety, and maintenance.

## Why

The course spans theory, modeling, fixed-point DSP, HDL/FPGA, SDR hardware, and IQ analysis. These checklists make future content additions more consistent, safer, and easier to review.

## Validation

- Documentation-only change.
- No MkDocs navigation or build behavior changed yet.
- No lab commands or hardware procedures changed.